### PR TITLE
price value fix

### DIFF
--- a/src/components/Shoes.jsx
+++ b/src/components/Shoes.jsx
@@ -104,7 +104,7 @@ const ProductCard = ({ name, imageUrl, prices, sources, productLinks }) => {
           {prices.map((priceObj, index) => (
             <p key={index} style={{ margin: '2px 0' }}>
               <span style={{ color: theme.silverLining }}>
-                ₹{parseFloat(priceObj.price).toFixed(2)}{' '}
+                ₹{priceObj.price}{'.00'}
               </span>
               <a
                 href={productLinks[index]}


### PR DESCRIPTION
The price value in string which came from the server had a comma, this created the issue when it was being converted into number using parseFloat() function
So, what I have done is directly rendered the string, because there is not need to convert it into number and added (hardcoded) ".00" at the end of it.